### PR TITLE
Fixed workflow_assigner

### DIFF
--- a/src/perl/lib/wtsi_clarity/epp/generic/workflow_assigner.pm
+++ b/src/perl/lib/wtsi_clarity/epp/generic/workflow_assigner.pm
@@ -44,7 +44,6 @@ override 'run' => sub {
   my $self= shift;
   super();
   my $response = $self->_main_method();
-  $self->check_response( $response );
 };
 
 


### PR DESCRIPTION
check_response method did not exist so script
was failing. Was superfluous anyway as response
is being checked, and croaking if fails
