### PR TITLE
Fixes #209

### DIFF
--- a/src/perl/lib/wtsi_clarity/epp/sm/dtx_file_attacher.pm
+++ b/src/perl/lib/wtsi_clarity/epp/sm/dtx_file_attacher.pm
@@ -43,7 +43,7 @@ has '_standard_barcode' => (
 sub _build__standard_barcode {
   my $self = shift;
 
-  my $standard_barcode = $self->find_udf_element($self->process_doc, 'Standard Barcode');
+  my $standard_barcode = $self->find_udf_element($self->process_doc, 'Standard File Barcode');
 
   croak 'Standard barcode has not been set' if (!defined $standard_barcode);
 

--- a/src/perl/t/data/epp/sm/dtx_file_attacher/GET/processes.24-3053
+++ b/src/perl/t/data/epp/sm/dtx_file_attacher/GET/processes.24-3053
@@ -575,6 +575,6 @@
     </input>
     <output limsid="92-7894" output-generation-type="PerAllInputs" output-type="SharedResultFile" uri="http://testserver.com:1234/here/artifacts/92-7894?state=3844"/>
   </input-output-map>
-  <udf:field name="Standard Barcode" type="Numeric">1234</udf:field>
+  <udf:field name="Standard File Barcode" type="String">1234</udf:field>
   <udf:field name="DTX ID" type="String">010464</udf:field>
 </prc:process>

--- a/src/perl/t/data/epp/sm/dtx_file_attacher/GET/processes.24-3053_a
+++ b/src/perl/t/data/epp/sm/dtx_file_attacher/GET/processes.24-3053_a
@@ -575,6 +575,6 @@
     </input>
     <output limsid="92-7894" output-generation-type="PerAllInputs" output-type="SharedResultFile" uri="http://testserver.com:1234/here/artifacts/92-7894?state=3844"/>
   </input-output-map>
-  <udf:field name="Standard Barcode" type="Numeric">1234</udf:field>
+  <udf:field name="Standard File Barcode" type="String">1234</udf:field>
   <udf:field name="DTX ID" type="String">010464</udf:field>
 </prc:process>

--- a/src/perl/t/data/epp/sm/dtx_file_attacher/GET/processes.24-3053_b
+++ b/src/perl/t/data/epp/sm/dtx_file_attacher/GET/processes.24-3053_b
@@ -575,6 +575,6 @@
     </input>
     <output limsid="92-7894" output-generation-type="PerAllInputs" output-type="SharedResultFile" uri="http://testserver.com:1234/here/artifacts/92-7894?state=3844"/>
   </input-output-map>
-  <udf:field name="Standard Barcode" type="Numeric">1234a</udf:field>
+  <udf:field name="Standard File Barcode" type="String">1234a</udf:field>
   <udf:field name="DTX ID" type="String">010464</udf:field>
 </prc:process>


### PR DESCRIPTION
Changed UDF from Standard Barcode to Standard File Barcode

For some reason Clarity does not let you change the types of UDFs.
Standard Barcode on Pico DTX was configured as a numeric which meant
that when it was saved, it was saved in eponential format. We use this
number to look up a file so really we need it as a string
