### PR TITLE
Fixes #245

### DIFF
--- a/src/perl/t/10-epp-sm-report_maker.t
+++ b/src/perl/t/10-epp-sm-report_maker.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 13;
+use Test::More tests => 15;
 use Test::Exception;
 use Test::Deep;
 use Test::MockObject::Extends;
@@ -17,10 +17,11 @@ use_ok('wtsi_clarity::epp::sm::report_maker');
 local $ENV{'WTSICLARITY_WEBCACHE_DIR'} = 't/data/epp/sm/report_maker';
 local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
-
 { # _get_artifact_uris_from_udf
   my $m = wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-25342'
   );
 
   my $res = $m->_get_artifact_uris_from_udf('Volume Check (SM)', qq{Volume});
@@ -37,7 +38,9 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
 { # _get_udf_values
   my $m = Test::MockObject::Extends->new( wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-25342'
   ) );
   $m->mock(q(_required_sources), sub{
       return {
@@ -78,7 +81,9 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
 { # _get_udf_values
   my $m = wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-25342'
   );
 
   my $res = $m->_get_udf_values('Picogreen Analysis (SM)', qq{Concentration});
@@ -107,7 +112,9 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
 { # _build__all_udf_values
   my $m = Test::MockObject::Extends->new( wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-25342'
   ) );
   $m->mock(q(_required_sources), sub{
       return {
@@ -171,7 +178,9 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
     'hello' => '_get_not_implemented_yet',
     };
   my $m = wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-25342'
   );
   while (my ($test, $expected) = each %{$testdata} ) {
     my $res = $m->get_method_from_header($test);
@@ -182,7 +191,9 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
 { # _get_first_missing_necessary_data
   my $m = Test::MockObject::Extends->new( wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-25342'
   ) );
   $m->mock(q(_required_sources), sub{
       return {
@@ -202,7 +213,9 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
 { # _get_first_missing_necessary_data
   my $m = Test::MockObject::Extends->new( wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-25342'
   ) );
   $m->mock(q(_required_sources), sub{
       return {
@@ -226,7 +239,8 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
 { # _build__all_udf_values
   my $m = Test::MockObject::Extends->new( wtsi_clarity::epp::sm::report_maker->new(
-    process_url => $base_uri . '/processes/24-25342'
+    process_url => $base_uri . '/processes/24-25342',
+    qc_report_file_name => '24-25342'
   ) );
   $m->mock(q(_required_sources), sub{
       return {
@@ -248,6 +262,27 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
    { $m->_main_method() }
    qr{Impossible to produce the report: "Impossible Value" could not be found on the genealogy of some samples. Have you run all the necessary steps on the samples?},
    q{_main_method should croak if not all the data are present.} ;
+}
+
+{
+  my $m = wtsi_clarity::epp::sm::report_maker->new(
+    process_url => $base_uri . '/processes/24-26114',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-26114'
+  );
+  # print Dumper $m->_get_value_from_data(qq{WTSI Fluidigm Call Rate (SM)}, 'DEA103A2087');
+  my $expected_volume = '16.1914';
+  is($m->_get_value_from_data(qq{Volume}, 'DEA103A2127'), $expected_volume, qq{_get_value_from_data should return the correct values.});
+}
+
+{
+  my $m = wtsi_clarity::epp::sm::report_maker->new(
+    process_url => $base_uri . '/processes/24-26114',
+    produce_report_anyway => 1,
+    qc_report_file_name => '24-26114'
+  );
+  my $expected_call_rate = '';
+  is($m->_get_value_from_data(qq{WTSI Fluidigm Call Rate (SM)}, 'DEA103A2127'), $expected_call_rate, qq{_get_value_from_data should return empty string for a missing value.});
 }
 
 1;

--- a/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Fluidigm%20Analysis&type=Analyte&udf.WTSI%20Fluidigm%20Call%20Rate%20(SM).min=0
+++ b/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Fluidigm%20Analysis&type=Analyte&udf.WTSI%20Fluidigm%20Call%20Rate%20(SM).min=0
@@ -1,0 +1,2 @@
+<?xml version="1.0" standalone="yes"?>
+<art:artifacts xmlns:art="http://genologics.com/ri/artifact"/>

--- a/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Fluidigm%20Analysis&type=Analyte&udf.WTSI%20Fluidigm%20Gender%20(SM).min=0
+++ b/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Fluidigm%20Analysis&type=Analyte&udf.WTSI%20Fluidigm%20Gender%20(SM).min=0
@@ -1,0 +1,2 @@
+<?xml version="1.0" standalone="yes"?>
+<art:artifacts xmlns:art="http://genologics.com/ri/artifact"/>

--- a/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Picogreen%20Analysis%20(SM)&type=Analyte&udf.Concentration.min=0
+++ b/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Picogreen%20Analysis%20(SM)&type=Analyte&udf.Concentration.min=0
@@ -1,0 +1,5 @@
+<?xml version="1.0" standalone="yes"?>
+<art:artifacts xmlns:art="http://genologics.com/ri/artifact">
+    <artifact limsid="2-148195" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148195"/>
+    <artifact limsid="2-148196" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148196"/>
+</art:artifacts>

--- a/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Volume%20Check%20(SM)&type=Analyte&udf.Volume.min=0
+++ b/src/perl/t/data/epp/sm/report_maker/GET/artifacts?samplelimsid=DEA103A2127&samplelimsid=DEA103A2128&samplelimsid=3C-454&process-type=Volume%20Check%20(SM)&type=Analyte&udf.Volume.min=0
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="yes"?>
+<art:artifacts xmlns:art="http://genologics.com/ri/artifact">
+    <artifact limsid="2-146674" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146674"/>
+    <artifact limsid="2-146675" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146675"/>
+    <artifact limsid="2-146676" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146676"/>
+</art:artifacts>

--- a/src/perl/t/data/epp/sm/report_maker/GET/processes.24-26114
+++ b/src/perl/t/data/epp/sm/report_maker/GET/processes.24-26114
@@ -1,0 +1,27 @@
+<?xml version="1.0" standalone="yes"?>
+<prc:process limsid="24-26114" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-26114" xmlns:file="http://genologics.com/ri/file" xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined">
+  <type uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processtypes/124">QC Report (SM)</type>
+  <technician uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/researchers/58">
+    <first-name>Karoly</first-name>
+    <last-name>Erdos</last-name>
+  </technician>
+  <input-output-map>
+    <input limsid="2-148193" post-process-uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148193?state=70697" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148193?state=70697">
+      <parent-process limsid="24-25617" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25617"/>
+    </input>
+    <output limsid="92-162090" output-generation-type="PerAllInputs" output-type="ResultFile" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/92-162090?state=77720"/>
+  </input-output-map>
+  <input-output-map>
+    <input limsid="2-148191" post-process-uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148191?state=70695" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148191?state=70695">
+      <parent-process limsid="24-25617" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25617"/>
+    </input>
+    <output limsid="92-162090" output-generation-type="PerAllInputs" output-type="ResultFile" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/92-162090?state=77720"/>
+  </input-output-map>
+  <input-output-map>
+    <input limsid="2-148195" post-process-uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148195?state=70699" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148195?state=70699">
+      <parent-process limsid="24-25617" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25617"/>
+    </input>
+    <output limsid="92-162090" output-generation-type="PerAllInputs" output-type="ResultFile" uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/92-162090?state=77720"/>
+  </input-output-map>
+  <process-parameter name="Make QC Report"/>
+</prc:process>

--- a/src/perl/t/data/epp/sm/report_maker/POST/artifacts.batch_03cd7c388a1b194c0ee1707c65ed1951
+++ b/src/perl/t/data/epp/sm/report_maker/POST/artifacts.batch_03cd7c388a1b194c0ee1707c65ed1951
@@ -1,0 +1,46 @@
+<?xml version="1.0" standalone="yes"?>
+<art:details xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact">
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146674?state=69928" limsid="2-146674">
+        <name>94</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25609" limsid="24-25609"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3568" limsid="27-3568"/>
+            <value>F:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/DEA103A2127" limsid="DEA103A2127"/>
+        <udf:field type="Numeric" name="Volume">16.1914</udf:field>
+    </art:artifact>
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146675?state=69929" limsid="2-146675">
+        <name>95</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25609" limsid="24-25609"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3568" limsid="27-3568"/>
+            <value>G:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/DEA103A2128" limsid="DEA103A2128"/>
+        <udf:field type="Numeric" name="Volume">29.3913</udf:field>
+    </art:artifact>
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146676?state=69930" limsid="2-146676">
+        <name>Stock plate control</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25609" limsid="24-25609"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3568" limsid="27-3568"/>
+            <value>H:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/3C-454" limsid="3C-454"/>
+        <control-type uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/controltypes/3"/>
+        <udf:field type="Numeric" name="Volume">27.4024</udf:field>
+    </art:artifact>
+</art:details>

--- a/src/perl/t/data/epp/sm/report_maker/POST/artifacts.batch_13c016a66f6a5243999504dbe234c9b0
+++ b/src/perl/t/data/epp/sm/report_maker/POST/artifacts.batch_13c016a66f6a5243999504dbe234c9b0
@@ -1,0 +1,33 @@
+<?xml version="1.0" standalone="yes"?>
+<art:details xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact">
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148195?state=70699" limsid="2-148195">
+        <name>Stock plate control</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25617" limsid="24-25617"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3581" limsid="27-3581"/>
+            <value>H:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/3C-454" limsid="3C-454"/>
+        <control-type uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/controltypes/3"/>
+        <udf:field type="Numeric" name="Concentration">14.1491496307091</udf:field>
+    </art:artifact>
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-148196?state=70700" limsid="2-148196">
+        <name>Stock plate control</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25617" limsid="24-25617"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3580" limsid="27-3580"/>
+            <value>H:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/3C-454" limsid="3C-454"/>
+        <control-type uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/controltypes/3"/>
+        <udf:field type="Numeric" name="Concentration">14.1491496307091</udf:field>
+    </art:artifact>
+</art:details>

--- a/src/perl/t/data/epp/sm/report_maker/POST/artifacts.batch_b5e4ac5cef06df616f2193929f1235dd
+++ b/src/perl/t/data/epp/sm/report_maker/POST/artifacts.batch_b5e4ac5cef06df616f2193929f1235dd
@@ -1,0 +1,46 @@
+<?xml version="1.0" standalone="yes"?>
+<art:details xmlns:udf="http://genologics.com/ri/userdefined" xmlns:file="http://genologics.com/ri/file" xmlns:art="http://genologics.com/ri/artifact">
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146674?state=69928" limsid="2-146674">
+        <name>94</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25609" limsid="24-25609"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3568" limsid="27-3568"/>
+            <value>F:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/DEA103A2127" limsid="DEA103A2127"/>
+        <udf:field type="Numeric" name="Volume">16.1914</udf:field>
+    </art:artifact>
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146675?state=69929" limsid="2-146675">
+        <name>95</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25609" limsid="24-25609"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3568" limsid="27-3568"/>
+            <value>G:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/DEA103A2128" limsid="DEA103A2128"/>
+        <udf:field type="Numeric" name="Volume">29.3913</udf:field>
+    </art:artifact>
+    <art:artifact uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/artifacts/2-146676?state=69930" limsid="2-146676">
+        <name>Stock plate control</name>
+        <type>Analyte</type>
+        <output-type>Analyte</output-type>
+        <parent-process uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/processes/24-25609" limsid="24-25609"/>
+        <qc-flag>UNKNOWN</qc-flag>
+        <location>
+            <container uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/containers/27-3568" limsid="27-3568"/>
+            <value>H:12</value>
+        </location>
+        <working-flag>true</working-flag>
+        <sample uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/samples/3C-454" limsid="3C-454"/>
+        <control-type uri="http://web-claritytest-01.internal.sanger.ac.uk:8080/api/v2/controltypes/3"/>
+        <udf:field type="Numeric" name="Volume">27.4024</udf:field>
+    </art:artifact>
+</art:details>


### PR DESCRIPTION
Fixed getting the value from the UDF fields. 
Returns an empty string in case of not existing fields.
Also adding the qc_report_file_name attribute.

I added a documentation on QC Report step into the Clarity shared directory under 'QCReport' folder.