### PR TITLE
Fix for Fluidigm report unneeded spaces issue

### DIFF
--- a/src/perl/lib/wtsi_clarity/genotyping/fluidigm_analysis.pm
+++ b/src/perl/lib/wtsi_clarity/genotyping/fluidigm_analysis.pm
@@ -114,12 +114,12 @@ has '_file_metadata' => (
 sub _build__file_metadata {
   my $self = shift;
   return [
-    'File Format, '  . $self->file_format  . ', , ',
-    'Sample Plate, ' . $self->sample_plate . ', , ',
-    'Barcode ID, '   . $self->barcode      . ', , ',
-    'Description, '  . $self->description  . ', , ',
-    'Plate Type, '   . $self->plate_type   . ', , ',
-    ' , , , ',
+    'File Format,'  . $self->file_format  . q{,,},
+    'Sample Plate,' . $self->sample_plate . q{,,},
+    'Barcode ID,'   . $self->barcode      . q{,,},
+    'Description,'  . $self->description  . q{,,},
+    'Plate Type,'   . $self->plate_type   . q{,,},
+    q{,,,},
   ];
 }
 

--- a/src/perl/lib/wtsi_clarity/util/csv/factories/generic_csv_writer.pm
+++ b/src/perl/lib/wtsi_clarity/util/csv/factories/generic_csv_writer.pm
@@ -16,11 +16,11 @@ sub build {
 
   my $text_data = [];
   my $c_headers = Mojo::Collection->new(@{$headers});
-  my $s_headers = $c_headers->join(', ');
+  my $s_headers = $c_headers->join(q{,});
   push @{$text_data},"$s_headers"; # quote are needed to stringify
 
   foreach my $datum (@{$csv_data}){
-    my $c_datum = $c_headers->map(sub { $datum->{$_} })->join(', ');
+    my $c_datum = $c_headers->map(sub { $datum->{$_} })->join(q{,});
     push @{$text_data},"$c_datum"; # quote are needed to stringify
   }
 

--- a/src/perl/t/10-epp-isc-pool-beckman.t
+++ b/src/perl/t/10-epp-isc-pool-beckman.t
@@ -21,9 +21,9 @@ local $ENV{'SAVE2WTSICLARITY_WEBCACHE'} = 0;
 
 {
   my $expected_result = [
-          'Sample, Name, Source EAN13, Source Barcode, Source Stock, Source Well, Destination EAN13, Destination Barcode, Destination Well, Source Volume',
-          '1, PCRXP1, Not used, Not used, Not used, A2, Not used, Not used, B1, 24.94',
-          '2, PCRXP1, Not used, Not used, Not used, A1, Not used, Not used, A1, 38.9'
+          'Sample,Name,Source EAN13,Source Barcode,Source Stock,Source Well,Destination EAN13,Destination Barcode,Destination Well,Source Volume',
+          '1,PCRXP1,Not used,Not used,Not used,A2,Not used,Not used,B1,24.94',
+          '2,PCRXP1,Not used,Not used,Not used,A1,Not used,Not used,A1,38.9'
         ];
   my $pooling_calculator_result = {
     'PCRXP1' => {

--- a/src/perl/t/10-genotyping-fluidigm_analysis.t
+++ b/src/perl/t/10-genotyping-fluidigm_analysis.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 18;
+use Test::More tests => 20;
 use Test::Exception;
 
 use_ok 'wtsi_clarity::genotyping::fluidigm_analysis';
@@ -144,12 +144,12 @@ use_ok 'wtsi_clarity::genotyping::fluidigm_analysis';
   my $samples = [];
 
   my $expected_metadata = [
-    'File Format, BioMark Sample Format V1.0, , ',
-    'Sample Plate, DN12312313Q, , ',
-    'Barcode ID, 123456789, , ',
-    'Description, DN12312313Q, , ',
-    'Plate Type, SBS96, , ',
-    ' , , , ',
+    'File Format,BioMark Sample Format V1.0,,',
+    'Sample Plate,DN12312313Q,,',
+    'Barcode ID,123456789,,',
+    'Description,DN12312313Q,,',
+    'Plate Type,SBS96,,',
+    ',,,',
   ];
 
   my $file = wtsi_clarity::genotyping::fluidigm_analysis->new(
@@ -177,15 +177,51 @@ use_ok 'wtsi_clarity::genotyping::fluidigm_analysis';
   ];
 
   my $expected_content = [
-    'File Format, BioMark Sample Format V1.0, , ',
-    'Sample Plate, DN12312313Q, , ',
-    'Barcode ID, 123456789, , ',
-    'Description, DN12312313Q, , ',
-    'Plate Type, SBS96, , ',
-    ' , , , ',
-    'Well Location, Sample Name, Sample Concentration, Sample Type',
-    'A01, sample01, 2.333, NTC',
-    'B01, sample02, , Unknown'
+    'File Format,BioMark Sample Format V1.0,,',
+    'Sample Plate,DN12312313Q,,',
+    'Barcode ID,123456789,,',
+    'Description,DN12312313Q,,',
+    'Plate Type,SBS96,,',
+    ',,,',
+    'Well Location,Sample Name,Sample Concentration,Sample Type',
+    'A01,sample01,2.333,NTC',
+    'B01,sample02,,Unknown'
+  ];
+
+  my $file = wtsi_clarity::genotyping::fluidigm_analysis->new(
+    sample_plate => 'DN12312313Q',
+    barcode      => 123456789,
+    samples      => $samples,
+  );
+
+  isa_ok($file->_textfile, 'wtsi_clarity::util::textfile', 'Creates a text file');
+  is_deeply($file->content, $expected_content, 'Creates the text file correctly');
+}
+
+# Test text file is created properly with empty concentration
+{
+  my $samples = [
+    {
+      well_location        => 'A01',
+      sample_name          => 'sample01',
+      sample_type          => 'NTC',
+    },
+    {
+      well_location => 'B01',
+      sample_name   => 'sample02',
+    }
+  ];
+
+  my $expected_content = [
+    'File Format,BioMark Sample Format V1.0,,',
+    'Sample Plate,DN12312313Q,,',
+    'Barcode ID,123456789,,',
+    'Description,DN12312313Q,,',
+    'Plate Type,SBS96,,',
+    ',,,',
+    'Well Location,Sample Name,Sample Concentration,Sample Type',
+    'A01,sample01,,NTC',
+    'B01,sample02,,Unknown'
   ];
 
   my $file = wtsi_clarity::genotyping::fluidigm_analysis->new(

--- a/src/perl/t/10-util-beckman.t
+++ b/src/perl/t/10-util-beckman.t
@@ -39,9 +39,9 @@ use_ok('wtsi_clarity::util::beckman', 'can use beckman');
                       },
                     ];
   my $expected_result = [
-          'Sample, Name, Source EAN13, Source Barcode, Source Stock, Source Well, Destination EAN13, Destination Barcode, Destination Well, Source Volume',
-          '1, 2, 4, g, 5, 6, 7, 8, 9, 10',
-          '2, 3, 4, h, 5, 6, 7, 8, 9, 10'
+          'Sample,Name,Source EAN13,Source Barcode,Source Stock,Source Well,Destination EAN13,Destination Barcode,Destination Well,Source Volume',
+          '1,2,4,g,5,6,7,8,9,10',
+          '2,3,4,h,5,6,7,8,9,10'
         ];
   my $file = $beckman->get_file($some_content);
   is_deeply($file->content, $expected_result, 'get_file returns a file object with the correct content');

--- a/src/perl/t/10-util-csv-factory-generic_csv_writer.t
+++ b/src/perl/t/10-util-csv-factory-generic_csv_writer.t
@@ -27,9 +27,9 @@ use_ok('wtsi_clarity::util::csv::factories::generic_csv_writer', 'can use csv::f
                       },
                     ];
   my $expected_result = [
-          'a, b, c',
-          '1, 2, 4',
-          '1, 4, 2',
+          'a,b,c',
+          '1,2,4',
+          '1,4,2',
         ];
   my $file = $csv_writer->build(headers=>$headers, data=> $some_content);
   is_deeply($file->content, $expected_result, 'build returns a file object with the correct content');

--- a/src/perl/t/10-util-report.t
+++ b/src/perl/t/10-util-report.t
@@ -57,9 +57,9 @@ use_ok('wtsi_clarity::util::report');
                       },
                     ];
   my $expected_result = [
-                "Status, Study, Supplier, Sanger Sample Name, Supplier Sample Name, Plate, Well, Supplier Volume, Supplier Gender, Concentration, Measured Volume, Total micrograms, Fluidigm Count, Fluidigm Gender, Genotyping Status, Genotyping Chip, Genotyping Infinium Barcode, Genotyping Barcode, Genotyping Well Cohort",
-                'a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a',
-                'b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b'
+                "Status,Study,Supplier,Sanger Sample Name,Supplier Sample Name,Plate,Well,Supplier Volume,Supplier Gender,Concentration,Measured Volume,Total micrograms,Fluidigm Count,Fluidigm Gender,Genotyping Status,Genotyping Chip,Genotyping Infinium Barcode,Genotyping Barcode,Genotyping Well Cohort",
+                'a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a',
+                'b,b,b,b,b,b,b,b,b,b,b,b,b,b,b,b,b,b,b'
         ];
   my $file = $w->get_file($some_content);
   is_deeply($file->content, $expected_result, 'get_file returns a file object with the correct content');


### PR DESCRIPTION
Removed unneeded spaces from the generated CSV files,
which are causing an issue when using it with the robot.