### PR TITLE
Fixes #265 - Bed Verification Input Only

### DIFF
--- a/src/perl/lib/wtsi_clarity/epp/generic/bed_verifier.pm
+++ b/src/perl/lib/wtsi_clarity/epp/generic/bed_verifier.pm
@@ -30,6 +30,15 @@ has 'step_name' => (
   required   => 1,
 );
 
+# Optional parameters
+has '_input_only' => (
+  is       => 'ro',
+  isa      => 'Bool',
+  required => 0,
+  default  => 0,
+  init_arg => 'input_only',
+);
+
 # Main method
 override 'run' => sub {
   my $self = shift;
@@ -63,7 +72,10 @@ has '_bed_verifier' => (
 
 sub _build__bed_verifier {
   my $self = shift;
-  return wtsi_clarity::process_checks::bed_verifier->new(config => $self->_bed_config_file);
+  return wtsi_clarity::process_checks::bed_verifier->new(
+    config     => $self->_bed_config_file,
+    input_only => $self->_input_only,
+  );
 }
 
 has '_bed_config_file' => (

--- a/src/perl/lib/wtsi_clarity/process_checks/bed_verifier.pm
+++ b/src/perl/lib/wtsi_clarity/process_checks/bed_verifier.pm
@@ -17,6 +17,15 @@ has 'config' => (
   required   => 1,
 );
 
+# Optional
+has '_input_only' => (
+  is       => 'ro',
+  isa      => 'Bool',
+  required => 0,
+  init_arg => 'input_only',
+  default  => 0,
+);
+
 sub verify {
   my ($self, $epp) = @_;
 
@@ -117,9 +126,21 @@ sub _verify_plate_mapping {
   my ($self, $epp, $plate_mapping) = @_;
 
   foreach my $plate_io (@{$epp->process_doc->plate_io_map_barcodes}) {
-    my $matches = grep { ($_->{'source_plate'} == $plate_io->{'source_plate'} && $_->{'dest_plate'} == $plate_io->{'dest_plate'}) } @{$plate_mapping};
-    if ($matches != 1) {
-      croak "Expected source plate " . $plate_io->{'source_plate'} . " to be paired with destination plate " . $plate_io->{'dest_plate'};
+    my $matches;
+
+    if ($self->_input_only) {
+      $matches = grep { $_->{'source_plate'} == $plate_io->{'source_plate'} } @{$plate_mapping};
+
+      if ($matches != 1) {
+        croak "Expected source plate " . $plate_io->{'source_plate'};
+      }
+
+    } else {
+      $matches = grep { ($_->{'source_plate'} == $plate_io->{'source_plate'} && $_->{'dest_plate'} == $plate_io->{'dest_plate'}) } @{$plate_mapping};
+
+      if ($matches != 1) {
+        croak "Expected source plate " . $plate_io->{'source_plate'} . " to be paired with destination plate " . $plate_io->{'dest_plate'};
+      }
     }
   }
 

--- a/src/perl/t/10-process_checks-bed_verifier.t
+++ b/src/perl/t/10-process_checks-bed_verifier.t
@@ -321,4 +321,34 @@ my $bed_verifier = wtsi_clarity::process_checks::bed_verifier->new(config => get
     'Throws when incorrect plates in beds 2 inputs => 1 output';
 }
 
+{
+  local $ENV{'WTSICLARITY_WEBCACHE_DIR'} = 't/data/epp/generic/bed_verifier/working_dilution/';
+
+  my $bed_verifier = wtsi_clarity::process_checks::bed_verifier->new(
+    config     => get_config(),
+    input_only => 1,
+  );
+
+  my $process = Test::MockObject->new();
+  my $process_doc = Test::MockObject->new();
+
+  $process_doc->mock(q{plate_io_map_barcodes}, sub {
+    return [
+      {source_plate => 1111},
+      {source_plate => 2222}
+    ];
+  });
+
+  $process->mock(q{process_doc}, sub {
+    return $process_doc;
+  });
+
+  my $plate_map = [
+    {source_plate => 1111, dest_plate => 3333},
+    {source_plate => 2222, dest_plate => 3333}
+  ];
+
+  is($bed_verifier->_verify_plate_mapping($process, $plate_map), 1, 'Input only test');
+}
+
 1;

--- a/src/perl/t/10-process_checks-bed_verifier.t
+++ b/src/perl/t/10-process_checks-bed_verifier.t
@@ -3,7 +3,7 @@ use warnings;
 use JSON;
 use utf8;
 use Moose::Meta::Class;
-use Test::More tests => 21;
+use Test::More tests => 22;
 use Test::Exception;
 use Test::MockObject;
 


### PR DESCRIPTION
Can now add `--input_only 1` flag to bed verifier epp. It will only
verify input plates