### PR TITLE
Fixing shadow stamps

### DIFF
--- a/src/perl/lib/wtsi_clarity/epp/generic/stamper.pm
+++ b/src/perl/lib/wtsi_clarity/epp/generic/stamper.pm
@@ -36,19 +36,7 @@ override 'run' => sub {
   super(); #call parent's run method
   $self->epp_log('Step url is ' . $self->step_url);
 
-  if ($self->shadow_plate && $self->copy_on_target ) {
-    croak qq{One cannot use the shadow plate stamping with the copy_on_target option!};
-  }
-
-  if ($self->group && $self->copy_on_target) {
-    croak q{One can not use the group stamping with the copy_on_target option!};
-  }
-
-  ##no critic ValuesAndExpressions::ProhibitMagicNumbers
-  if ($self->group && $self->process_doc->input_artifacts->findnodes('/art:details/art:artifact')->size() > 96) {
-    croak q{Can not do a group stamp for more than 96 inputs!};
-  }
-  ##use critic
+  $self->_check_options();
 
   $self->_create_containers();
   my $doc = $self->_create_placements_doc;
@@ -71,6 +59,31 @@ override 'run' => sub {
 
   return;
 };
+
+sub _check_options {
+  my $self = shift;
+
+  if ($self->shadow_plate && $self->copy_on_target ) {
+    croak qq{One cannot use the shadow plate stamping with the copy_on_target option!};
+  }
+
+  if ($self->shadow_plate && $self->has_container_type_name) {
+    $self->epp_log(q{Argument container_type_name should not be provided when shadow stamping. Output container type(s) will match input container type(s)});
+    $self->clear_container_type_name;
+  }
+
+  if ($self->group && $self->copy_on_target) {
+    croak q{One can not use the group stamping with the copy_on_target option!};
+  }
+
+  ##no critic ValuesAndExpressions::ProhibitMagicNumbers
+  if ($self->group && $self->process_doc->input_artifacts->findnodes('/art:details/art:artifact')->size() > 96) {
+    croak q{Can not do a group stamp for more than 96 inputs!};
+  }
+  ##use critic
+
+  return 1;
+}
 
 ##
 
@@ -101,6 +114,8 @@ has 'container_type_name' => (
   isa        => 'ArrayRef[Str]',
   is         => 'ro',
   required   => 0,
+  predicate  => 'has_container_type_name',
+  clearer    => 'clear_container_type_name',
   lazy_build => 1,
 );
 sub _build_container_type_name {

--- a/src/perl/lib/wtsi_clarity/epp/generic/stamper.pm
+++ b/src/perl/lib/wtsi_clarity/epp/generic/stamper.pm
@@ -114,8 +114,6 @@ has 'container_type_name' => (
   isa        => 'ArrayRef[Str]',
   is         => 'ro',
   required   => 0,
-  predicate  => 'has_container_type_name',
-  clearer    => 'clear_container_type_name',
   lazy_build => 1,
 );
 sub _build_container_type_name {

--- a/src/perl/t/10-epp-generic-stamper.t
+++ b/src/perl/t/10-epp-generic-stamper.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 54;
+use Test::More tests => 58;
 use Test::Exception;
 use File::Temp qw/tempdir/;
 use File::Slurp;
@@ -13,6 +13,22 @@ my $base_uri =  'http://testserver.com:1234/here' ;
 {
   my $s = wtsi_clarity::epp::generic::stamper->new(process_url => 'some', step_url => 'some');
   isa_ok($s, 'wtsi_clarity::epp::generic::stamper');
+}
+
+{
+  my $s = wtsi_clarity::epp::generic::stamper->new(
+    process_url         => 'http://not_important',
+    step_url            => 'http://not_important',
+    shadow_plate        => 1,
+    container_type_name => ['ABgene 0800']
+  );
+
+  is($s->has_container_type_name, 1, 'Container type name has been set and the predicate says so');
+  is_deeply($s->container_type_name, ['ABgene 0800'], 'The container_type_name is set correctly');
+
+  is($s->_check_options, 1, 'Running check options returns 1 as the options are fine (although a warning will be produced)');
+
+  is($s->has_container_type_name, q{}, 'has_container_type should be cleared because we are doing a shadow stamp');
 }
 
 {


### PR DESCRIPTION
Moved the checking of options to a separate method, as there
are quite a few now. Added in a check to see if both shadow_plate
has been set and container_type_name has been provided. If both
true the user will get a warning and the container_type_name will
be cleared.

The container_type_name will then be determined from the input
container, which is what we want for shadow stamping.