### PR TITLE
Release Candidate 1.6

### DIFF
--- a/src/perl/lib/wtsi_clarity/epp/generic/stamper.pm
+++ b/src/perl/lib/wtsi_clarity/epp/generic/stamper.pm
@@ -36,19 +36,7 @@ override 'run' => sub {
   super(); #call parent's run method
   $self->epp_log('Step url is ' . $self->step_url);
 
-  if ($self->shadow_plate && $self->copy_on_target ) {
-    croak qq{One cannot use the shadow plate stamping with the copy_on_target option!};
-  }
-
-  if ($self->group && $self->copy_on_target) {
-    croak q{One can not use the group stamping with the copy_on_target option!};
-  }
-
-  ##no critic ValuesAndExpressions::ProhibitMagicNumbers
-  if ($self->group && $self->process_doc->input_artifacts->findnodes('/art:details/art:artifact')->size() > 96) {
-    croak q{Can not do a group stamp for more than 96 inputs!};
-  }
-  ##use critic
+  $self->_check_options();
 
   $self->_create_containers();
   my $doc = $self->_create_placements_doc;
@@ -71,6 +59,31 @@ override 'run' => sub {
 
   return;
 };
+
+sub _check_options {
+  my $self = shift;
+
+  if ($self->shadow_plate && $self->copy_on_target ) {
+    croak qq{One cannot use the shadow plate stamping with the copy_on_target option!};
+  }
+
+  if ($self->shadow_plate && $self->has_container_type_name) {
+    $self->epp_log(q{Argument container_type_name should not be provided when shadow stamping. Output container type(s) will match input container type(s)});
+    $self->clear_container_type_name;
+  }
+
+  if ($self->group && $self->copy_on_target) {
+    croak q{One can not use the group stamping with the copy_on_target option!};
+  }
+
+  ##no critic ValuesAndExpressions::ProhibitMagicNumbers
+  if ($self->group && $self->process_doc->input_artifacts->findnodes('/art:details/art:artifact')->size() > 96) {
+    croak q{Can not do a group stamp for more than 96 inputs!};
+  }
+  ##use critic
+
+  return 1;
+}
 
 ##
 

--- a/src/perl/lib/wtsi_clarity/process_checks/bed_verifier.pm
+++ b/src/perl/lib/wtsi_clarity/process_checks/bed_verifier.pm
@@ -86,6 +86,10 @@ sub _verify_robot_config {
 sub _verify_bed_barcodes {
   my ($self, $epp) = @_;
 
+  if (scalar @{$epp->beds} == 0 ) {
+    croak 'The barcode of the bed(s) are empty. Please, add barcode value(s) to the form.';
+  }
+
   foreach my $bed (@{$epp->beds}) {
     if (!exists $self->_robot_config->{$bed->bed_name}) {
       croak $bed->bed_name . ' can not be found in config for specified robot';

--- a/src/perl/t/10-epp-generic-stamper.t
+++ b/src/perl/t/10-epp-generic-stamper.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 54;
+use Test::More tests => 58;
 use Test::Exception;
 use File::Temp qw/tempdir/;
 use File::Slurp;
@@ -13,6 +13,22 @@ my $base_uri =  'http://testserver.com:1234/here' ;
 {
   my $s = wtsi_clarity::epp::generic::stamper->new(process_url => 'some', step_url => 'some');
   isa_ok($s, 'wtsi_clarity::epp::generic::stamper');
+}
+
+{
+  my $s = wtsi_clarity::epp::generic::stamper->new(
+    process_url         => 'http://not_important',
+    step_url            => 'http://not_important',
+    shadow_plate        => 1,
+    container_type_name => ['ABgene 0800']
+  );
+
+  is($s->has_container_type_name, 1, 'Container type name has been set and the predicate says so');
+  is_deeply($s->container_type_name, ['ABgene 0800'], 'The container_type_name is set correctly');
+
+  is($s->_check_options, 1, 'Running check options returns 1 as the options are fine (although a warning will be produced)');
+
+  is($s->has_container_type_name, q{}, 'has_container_type should be cleared because we are doing a shadow stamp');
 }
 
 {

--- a/src/perl/t/10-process_checks-bed_verifier.t
+++ b/src/perl/t/10-process_checks-bed_verifier.t
@@ -3,7 +3,7 @@ use warnings;
 use JSON;
 use utf8;
 use Moose::Meta::Class;
-use Test::More tests => 22;
+use Test::More tests => 23;
 use Test::Exception;
 use Test::MockObject;
 
@@ -112,6 +112,15 @@ my $bed_verifier = wtsi_clarity::process_checks::bed_verifier->new(config => get
   throws_ok { $bed_verifier->_verify_bed_barcodes($process3) }
     qr/Bed 2 barcode \(12345\) differs from config bed barcode \(580040002672\)/,
     'Throws an error when a bed has different barcode to the config';
+
+  my $process4 = $epp->new_object(
+    step_name => 'working_dilution',
+    process_url => $base_url . 'processes/24-102433_e',
+  );
+
+  throws_ok { $bed_verifier->_verify_bed_barcodes($process4) }
+    qr/The barcode of the bed\(s\) are empty. Please, add barcode value\(s\) to the form./,
+    'Throws an error when no bed has barcodes filled in';
 }
 
 # Plate Mappings

--- a/src/perl/t/data/epp/generic/bed_verifier/working_dilution/GET/processes.122-26353
+++ b/src/perl/t/data/epp/generic/bed_verifier/working_dilution/GET/processes.122-26353
@@ -1151,6 +1151,8 @@
   <udf:field name="Select Barcode Printer" type="String">dnapbc2</udf:field>
   <udf:field name="Plate Purpose" type="String">ReArray</udf:field>
   <udf:field name="Robot ID" type="String">0023751</udf:field>
+  <udf:field type="String" name="Bed 2 (Input Plate 1)">580000002810</udf:field>
+  <udf:field type="String" name="Bed 3 (Output Plate 1)">580000003824</udf:field>
   <udf:field name="Input Plate 1" type="String">2460274028854</udf:field>
   <udf:field name="Output Plate 1" type="String">2460274034831</udf:field>
   <udf:field name="Barcode Prefix" type="String">IC</udf:field>

--- a/src/perl/t/data/epp/generic/bed_verifier/working_dilution/GET/processes.24-102433_e
+++ b/src/perl/t/data/epp/generic/bed_verifier/working_dilution/GET/processes.24-102433_e
@@ -1,0 +1,13 @@
+<?xml version="1.0" standalone="yes"?>
+<prc:process limsid="24-102433" uri="http://testserver.com:1234/here/processes/24-102433" xmlns:file="http://genologics.com/ri/file" xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined">
+    <type uri="http://testserver.com:1234/here/processtypes/454">Working Dilution (SM)</type>
+    <technician uri="http://testserver.com:1234/here/researchers/254">
+        <first-name>Christopher</first-name>
+        <last-name>Smith</last-name>
+    </technician>
+    <input-output-map>
+        <input limsid="JON1407A1132PA1" post-process-uri="http://testserver.com:1234/here/artifacts/JON1407A1132PA1?state=336096" uri="http://testserver.com:1234/here/artifacts/JON1407A1132PA1?state=336096"/>
+        <output limsid="2-688667" output-generation-type="PerInput" output-type="Analyte" uri="http://testserver.com:1234/here/artifacts/2-688667?state=371137"/>
+    </input-output-map>
+    <udf:field type="String" name="Robot ID">009851</udf:field>
+</prc:process>


### PR DESCRIPTION
Contains the following fixes:
- Fixes #418 - Shadow stamping not creating correct output type
  The container_type_name will be determined from the input container, which is what we want for shadow stamping.
- #426 from ke4/fix_missing_validation_in_bed_verification
  added a check when bed fields are empty